### PR TITLE
Fix: CDN Purge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           inlineScript: |
             az account set --subscription "Productive_Sites"
-            az afd endpoint purge --content-paths  "/*" --profile-name "coiteu" --endpoint-name "coiteu" --resource-group "coIteu"
+            az afd endpoint purge --content-paths  "/*" --profile-name "coiteu" --endpoint-name "coiteu" --resource-group "coIteu" --domains "co-it.eu"
       - name: Azure logout
         run: |
             az logout


### PR DESCRIPTION
Weil beim CDN jetzt eine wildcard Domain hinterlegt ist, muss beim purge command eine Liste an zu bereinigenden Domains angegeben werden.